### PR TITLE
Add a key= to let React native distinguish different elements.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ export default class Autolink extends Component {
 
     return (
       <Text
+        key={text}
         style={[styles.link, this.props.linkStyle]}
         onPress={this._onPress.bind(this, url, match)}>
           {truncated}


### PR DESCRIPTION
Fixes this warning:

```Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `Autolink`. See https://fb.me/react-warning-keys for more information.```