### PR TITLE
Fix key= again.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,11 +7,11 @@
  */
 'use strict';
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
 
@@ -84,13 +84,13 @@ var Autolink = function (_Component) {
     }
   }, {
     key: 'renderLink',
-    value: function renderLink(text, url, match) {
+    value: function renderLink(text, url, match, index) {
       var truncated = this.props.truncate > 0 ? _autolinker2.default.truncate.TruncateSmart(text, this.props.truncate, this.props.truncateChars) : text;
 
       return _react2.default.createElement(
         _reactNative.Text,
         {
-          key: text,
+          key: index,
           style: [styles.link, this.props.linkStyle],
           onPress: this._onPress.bind(this, url, match) },
         truncated
@@ -141,7 +141,7 @@ var Autolink = function (_Component) {
 
       var nodes = text.split(tokenRegexp).filter(function (part) {
         return !!part;
-      }).map(function (part) {
+      }).map(function (part, index) {
         var match = matches[part];
 
         if (!match) return part;
@@ -152,7 +152,7 @@ var Autolink = function (_Component) {
           case 'phone':
           case 'twitter':
           case 'url':
-            return _this2.props.renderLink ? _this2.props.renderLink(match.getAnchorText(), _this2.getURL(match), match) : _this2.renderLink(match.getAnchorText(), _this2.getURL(match), match);
+            return _this2.props.renderLink ? _this2.props.renderLink(match.getAnchorText(), _this2.getURL(match), match, index) : _this2.renderLink(match.getAnchorText(), _this2.getURL(match), match, index);
           default:
             return part;
         }
@@ -168,6 +168,7 @@ var Autolink = function (_Component) {
 }(_react.Component);
 
 exports.default = Autolink;
+
 
 var styles = _reactNative.StyleSheet.create({
   link: {

--- a/src/index.js
+++ b/src/index.js
@@ -50,12 +50,12 @@ export default class Autolink extends Component {
     }
   }
 
-  renderLink(text, url, match) {
+  renderLink(text, url, match, index) {
     let truncated = (this.props.truncate > 0) ? Autolinker.truncate.TruncateSmart(text, this.props.truncate, this.props.truncateChars) : text;
 
     return (
       <Text
-        key={text}
+        key={index}
         style={[styles.link, this.props.linkStyle]}
         onPress={this._onPress.bind(this, url, match)}>
           {truncated}
@@ -103,7 +103,7 @@ export default class Autolink extends Component {
     let nodes = text
       .split(tokenRegexp)
       .filter((part) => !!part)
-      .map((part) => {
+      .map((part, index) => {
         let match = matches[part];
 
         if (!match) return part;
@@ -114,7 +114,7 @@ export default class Autolink extends Component {
           case 'phone':
           case 'twitter':
           case 'url':
-            return (this.props.renderLink) ? this.props.renderLink(match.getAnchorText(), this.getURL(match), match) : this.renderLink(match.getAnchorText(), this.getURL(match), match);
+            return (this.props.renderLink) ? this.props.renderLink(match.getAnchorText(), this.getURL(match), match, index) : this.renderLink(match.getAnchorText(), this.getURL(match), match, index);
           default:
             return part;
         }


### PR DESCRIPTION
If the text includes the same link more than once, we'd get these errors:

Warning: flattenChildren(...): Encountered two children with the same key, `udeftour.org`. Child keys must be unique; when two children share a key, only the first child will be used.

This passes in the map index counter to ensure this can't happen.