### PR TITLE
allow passing config object to autolinker.js urls property

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ class MyComponent extends Component {
 | `mention` | `Boolean/String` | `false` | Enable mention/handle linking to supplied service. Possible values: `false`, `"instagram"`, `"twitter"`. |
 | `phone` | `Boolean/String` | `true` | Enable phone linking (`tel:{number}`, `sms:{number}`) for calling/texting. Possible values: `false`, `"text"`|
 | `twitter` | `Boolean` | `false` | **DEPRECATED. Use `mention` prop.** Enable Twitter handle linking (`twitter://user?screen_name={handle}`). |
-| `url` | `Boolean` | `true` | Enable url linking (`https://{url}`). |
+| `urls` | `Boolean/Object` | `true` | Enable url linking (`https://{url}`). Possible values: true/false or {schemeMatches: true/false, wwwMatches: true/false, tldMatches: true/false}} |
 | `stripPrefix` | `Boolean` | `true` | Enable stripping of protocol from link text (`https://url` -> `url`). |
 | `linkStyle` | `TextStyle` | | Custom styling to apply to Text nodes of links. |
 | `onPress` | `function` | | Custom function handler for link press events. Arguments: `url:String`, [`match:Object`][match-url]. |
@@ -60,3 +60,7 @@ class MyComponent extends Component {
 [npm-url]: https://www.npmjs.com/package/react-native-autolink
 [npm-image]: https://badge.fury.io/js/react-native-autolink.svg
 [match-url]: http://greg-jacobs.com/Autolinker.js/api/index.html#!/api/Autolinker.match.Match
+
+## Live Example
+
+You can try autolinker.js options in [Live Example](http://greg-jacobs.com/Autolinker.js/examples/live-example/)

--- a/src/index.js
+++ b/src/index.js
@@ -252,6 +252,13 @@ Autolink.propTypes = {
   truncate: PropTypes.number,
   truncateChars: PropTypes.string,
   twitter: PropTypes.bool,
-  url: PropTypes.bool,
+  url: PropTypes.oneOfType(
+    PropTypes.bool,
+    PropTypes.shape({
+      schemeMatches: PropTypes.bool,
+      wwwMatches:    PropTypes.bool,
+      tldMatches:    PropTypes.bool
+    })
+  ),
   webFallback: PropTypes.bool,
 };

--- a/test/test.js
+++ b/test/test.js
@@ -74,6 +74,26 @@ describe('<Autolink />', () => {
     expect(wrapper.find('Text')).to.have.length(2);
   });
 
+  it('should match top-level domain url when wwwMatches enabled', () => {
+    const wrapper = shallow(<Autolink text="github.com" url={{tldMatches: true}} />);
+    expect(wrapper.find('Text')).to.have.length(2);
+  });
+
+  it('should not match top-level domain url when wwwMatches disabled', () => {
+    const wrapper = shallow(<Autolink text="github.com" url={{tldMatches: false}} />);
+    expect(wrapper.find('Text')).to.have.length(1);
+  });
+
+  it('should not match www containing url when wwwMatches disabled', () => {
+    const wrapper = shallow(<Autolink text="www.github.com" url={{wwwMatches: false}} />);
+    expect(wrapper.find('Text')).to.have.length(1);
+  });
+
+  it('should not match scheme containing url when schemeMatches disabled', () => {
+    const wrapper = shallow(<Autolink text="http://github.com" url={{schemeMatches: false}} />);
+    expect(wrapper.find('Text')).to.have.length(1);
+  });
+
   it('should not wrap a url in a Text node when url prop disabled', () => {
     const wrapper = shallow(<Autolink text="https://github.com/joshswan/react-native-autolink" url={false} />);
     expect(wrapper.find('Text')).to.have.length(1);


### PR DESCRIPTION
Now it's possible to pass object config as `url` option, e.g. `(<Autolink text="github.com" url={{tldMatches: true}}`, but you get a warning.

Autolinker.js have support for this http://greg-jacobs.com/Autolinker.js/api/#!/api/Autolinker-cfg-urls 

PR changes `url` property type to allow this.
