### PR TITLE
Update propTypes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -299,7 +299,10 @@ Autolink.propTypes = {
   numberOfLines: PropTypes.number,
   onPress: PropTypes.func,
   onLongPress: PropTypes.func,
-  phone: PropTypes.bool,
+  phone: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+  ]),
   renderLink: PropTypes.func,
   showAlert: PropTypes.bool,
   stripPrefix: PropTypes.bool,


### PR DESCRIPTION
Now that the `phone` prop can support the string "text" to open up in messages instead of attempt to phone the number the propType needs to change to support both booleans and string.