### PR TITLE
Extract `truncateLocation` from props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -199,6 +199,7 @@ export default class Autolink extends PureComponent {
       text,
       truncate,
       truncateChars,
+      truncateLocation,
       twitter,
       url,
       webFallback,


### PR DESCRIPTION
Currently `truncateLocation` is read as an "other" prop and sent into `<Text>`, which if you're using React Native Web (https://github.com/necolas/react-native-web) raises the warning: 

```Warning: React does not recognize the `truncateLocation` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `truncatelocation` instead. If you accidentally passed it from a parent component, remove it from the DOM element.```

I am not sure if swallowing it here has other implications.