### PR TITLE
Import React in Typescript typing

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { StyleProp, TextStyle } from 'react-native';
 
 export interface AutolinkProps {


### PR DESCRIPTION
Thank you for adding Typescript types in the last version!

I got the following error:

```
node_modules/react-native-autolink/src/index.d.ts:26:39 - error TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.

26 export default class Autolink extends React.PureComponent<AutolinkProps> {
```

I fixed it by adding `import React from 'react'` at the top of the TS definition.

CC @mo22, maybe you also can give his thumbs up on this PR.