### PR TITLE
Feature: user-specified custom link pattern handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ class MyComponent extends Component {
 ## Props
 
 - [`component?`](#component)
+- [`customLinks?`](#customLinks)
 - [`email?`](#email)
 - [`hashtag?`](#hashtag)
 - [`latlng?`](#latlng)
@@ -65,6 +66,51 @@ class MyComponent extends Component {
 
 ```js
 <Autolink text={text} component={View} />
+```
+
+### `customLinks`
+
+|          Type           | Required | Default | Description |
+| ----------------------- | -------- | ------- | ----------- |
+| `UserCustomMatchSpec[]` |    No    |         | Specifications for custom link patterns and their handling (see below). |
+
+This property allows the user to establish custom link patterns and handling. It is particularly useful for mixing internal app navigation links with standard external links within the same block of content.
+
+```ts
+interface UserCustomMatchSpec {
+  /** Regular expression pattern to match user-specified custom links */
+  pattern: RegExp;
+  /** Custom function for extracting link text from regex replacer args */
+  extractText?: (replacerArgs: ReplacerArgs) => string;
+  /** Custom function for extracting link URL from regex replacer args */
+  extractUrl?: (replacerArgs: ReplacerArgs) => string;
+  /** Custom override for styling links of this type */
+  style?: StyleProp<TextStyle>;
+  /** Custom override for handling presses on links of this type */
+  onPress?: (replacerArgs: ReplacerArgs) => void;
+  /** Custom override for handling long-presses on links of this type */
+  onLongPress?: (replacerArgs: ReplacerArgs) => void;
+}
+```
+
+The `ReplacerArgs` type is an array containing the variadic arguments passed to a replacer function as provided to `String.replace`. Essentially, element 0 is the entire matched link, and elements 1 through N are any captured subexpressions. More details can be found [in this documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_function_as_a_parameter).
+
+When using the built-in link handling, the `extractUrl` function can be provided to determine the URL to which the link should navigate. Alternatively the `onPress` function will bypass that entirely, allowing the user to provide custom handling specific to this link type, useful for navigating within the application.
+
+The following hypothetical example handles custom @-mention links of the format `@[Name](userId)`, navigating to a user profile screen:
+
+```tsx
+<Autolink
+  text={text}
+  customLinks={[{
+    pattern: /@\[([^[]*)]\(([^(^)]*)\)/g,
+    style: { color: '#ff00ff' },
+    extractText: (args) => `@${args[1]}`,
+    onPress: (args) => {
+      navigate('userProfile', { userId: args[2] });
+    },
+  }]}
+/>
 ```
 
 ### `email`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,6 +31,8 @@ import { Matchers, MatcherId, LatLngMatch } from './matchers';
 import { UserCustomMatch, UserCustomMatchSpec } from './user-custom-match';
 import { PropsOf } from './types';
 
+export * from './user-custom-match';
+
 const tagBuilder = new AnchorTagBuilder();
 
 const styles = StyleSheet.create({

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -49,4 +49,4 @@ export const CustomMatchers = {
 
 export type MatcherId = keyof typeof CustomMatchers;
 
-export const Matchers = Object.keys(CustomMatchers).map((key) => CustomMatchers[key as MatcherId]);
+export const Matchers = Object.values(CustomMatchers);

--- a/src/user-custom-match.ts
+++ b/src/user-custom-match.ts
@@ -1,0 +1,80 @@
+import { Match, MatchConfig } from 'autolinker/dist/es2015';
+import { StyleProp, TextStyle } from 'react-native';
+
+// The variadic arguments of a regex replacer function, wrapped in an array.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ReplacerArgs = [string, ...any[]];
+
+export interface UserCustomMatchSpec {
+  /** Regular expression pattern to match user-specified custom links */
+  pattern: RegExp;
+  /** Custom function for extracting link text from regex replacer args */
+  extractText?: (replacerArgs: ReplacerArgs) => string;
+  /** Custom function for extracting link URL from regex replacer args */
+  extractUrl?: (replacerArgs: ReplacerArgs) => string;
+  /** Custom override for styling links of this type */
+  style?: StyleProp<TextStyle>;
+  /** Custom override for handling presses on links of this type */
+  onPress?: (replacerArgs: ReplacerArgs) => void;
+  /** Custom override for handling long-presses on links of this type */
+  onLongPress?: (replacerArgs: ReplacerArgs) => void;
+}
+
+export interface UserCustomMatchConfig extends MatchConfig, UserCustomMatchSpec {
+  replacerArgs: ReplacerArgs;
+}
+
+export class UserCustomMatch extends Match {
+  private replacerArgs: ReplacerArgs;
+
+  private extractUrl?: (replacerArgs: ReplacerArgs) => string;
+
+  private extractText?: (replacerArgs: ReplacerArgs) => string;
+
+  private style?: StyleProp<TextStyle>;
+
+  private onPress?: () => void;
+
+  private onLongPress?: () => void;
+
+  constructor(cfg: UserCustomMatchConfig) {
+    super(cfg);
+
+    this.replacerArgs = cfg.replacerArgs;
+    this.extractUrl = cfg.extractUrl;
+    this.extractText = cfg.extractText;
+    this.style = cfg.style;
+
+    const { onPress, onLongPress } = cfg;
+    if (onPress) {
+      this.onPress = () => onPress(this.replacerArgs);
+    }
+    if (onLongPress) {
+      this.onLongPress = () => onLongPress(this.replacerArgs);
+    }
+  }
+
+  getType(): string {
+    return 'userCustom';
+  }
+
+  getAnchorHref(): string {
+    return this.extractUrl?.(this.replacerArgs) ?? this.matchedText;
+  }
+
+  getAnchorText(): string {
+    return this.extractText?.(this.replacerArgs) ?? this.matchedText;
+  }
+
+  getStyle(): StyleProp<TextStyle> | undefined {
+    return this.style;
+  }
+
+  getOnPress(): (() => void) | undefined {
+    return this.onPress;
+  }
+
+  getOnLongPress(): (() => void) | undefined {
+    return this.onLongPress;
+  }
+}


### PR DESCRIPTION
Hello, thanks for providing this awesome library! We've been using it for a long time now, since v1. We're in the process of adding @-mentions to our app, using react-native-controlled-mentions. We need the ability to render those encoded mentions as links to user profiles to be handled internally by app navigation, but we want to keep the ability to render external links as well. For example:

![image](https://user-images.githubusercontent.com/9442662/112530892-53208280-8d7d-11eb-8c0e-afcd5802e6ce.png)

I created a patch to your library to allow users to specify link regex patterns with custom styling and handling to allow us to accomplish this. I thought this might be helpful for a wider variety of uses, as discussed previously in #30 and #25 as well as others, so I am providing this PR. The new logic does however take a slightly different approach, allowing the user to specify styles and press handlers specific to a link type rather than using the top-level override functions. So I will understand if you do not want to incorporate these changes.