### PR TITLE
Expose AutolinkComponentProps type

### DIFF
--- a/src/Autolink.tsx
+++ b/src/Autolink.tsx
@@ -69,7 +69,7 @@ export interface AutolinkProps {
   useNativeSchemes?: boolean;
 }
 
-type AutolinkComponentProps<C extends React.ElementType = typeof Text> = PolymorphicComponentProps<
+export type AutolinkComponentProps<C extends React.ElementType = typeof Text> = PolymorphicComponentProps<
   C,
   AutolinkProps
 >;


### PR DESCRIPTION
Make this prop available so consuming applications don't have to manually re-type it.